### PR TITLE
Darken borders of input boxes and courseware div separation

### DIFF
--- a/static/_mitx.scss
+++ b/static/_mitx.scss
@@ -148,17 +148,17 @@ $action-secondary-disabled-fg: $gray;
 
 //
 
-$border-color-1: $beige-60;
-$border-color-2: $beige-60;
-$border-color-3: $beige-60;
-$outer-border-color: $beige-60;
+$border-color-1: $beige;
+$border-color-2: $beige;
+$border-color-3: $beige;
+$outer-border-color: $beige;
 
 $sidebar-color: $gray-1;
 
 $dashboard-profile-header-image: none;
 $dashboard-profile-header-color: $sandstone-25;
 $dashboard-profile-color: $gray-3;
-$dot-color: $beige-60;
+$dot-color: $beige;
 
 $course-bg-color: $gray-3;
 $course-bg-image: none;


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/596029/4909228/ae68a44c-6471-11e4-9181-749e5e8785e9.png)

After:
![image](https://cloud.githubusercontent.com/assets/596029/4909242/c1c71622-6471-11e4-93cf-c5eae3040b68.png)

It has been really hard to see text input boxes and such on an older monitor I have. Any objections to darkening these borders 18.5% ? @ichuang @JoeMartis @Ferdi @pdpinch 
